### PR TITLE
[PRJHW-3602] Update sdk version to fix mifare detection crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         kotlin_version = '2.1.21'
-        stone_sdk_version = '4.15.0'
+        stone_sdk_version = '4.16.2'
 
         localProp = new Properties()
         fileName = 'local.properties'


### PR DESCRIPTION
# Descrição


  Atualiza a versão do `stone-sdk` consumida pelo demo de **4.15.0** para **4.16.2**, incorporando a correção do crash em fluxos de detecção Mifare em dispositivos cuja HAL não implementa esse recurso.

  ## Contexto
  
  A `MifareActivity` do demo crashava com `kotlin.NotImplementedError: An operation is not implemented` (proveniente de `SerialMifare.detectCards`) quando o app rodava com um build que recaía na HAL serial (stub) em vez do HAL do fabricante. O crash matava o processo via `AndroidRuntime: FATAL EXCEPTION: AsyncTask #1`, sem qualquer feedback ao usuário.
  
  Stack do crash original:

  FATAL EXCEPTION: AsyncTask #1
  Caused by: kotlin.NotImplementedError: An operation is not implemented.
      at br.com.stone.posandroid.hal.serial.mifare.SerialMifare.detectCards(SerialMifare.kt:9)
      at br.com.stone.posandroid.hal.compiler.log.generated.MifareLogger.detectCards(MifareLogger.kt:17)
      at br.com.stone.posandroid.providers.PosMifareProvider.doInBackground(PosMifareProvider.kt:60)

  ## O que mudou

  * Bump de `stone_sdk_version`: `4.15.0` → `4.16.2` em `build.gradle`

  A `4.16.2` carrega o fix defensivo introduzido em [stone-payments/pos-android-sdk#1525](https://github.com/stone-payments/pos-android-sdk/pull/1525), que:

  - envolve `detectCards` e operações síncronas do Mifare em `try/catch` para `NotImplementedError` e `UnsupportedOperationException`;
  - traduz essas falhas em `ErrorsEnum.NO_MIFARE_SUPPORT`, propagado pelo `connectionCallback.onError()` em vez de derrubar a AsyncTask;
  - adiciona guard contra `getMifare()` retornar `null` (deadlock no `conditionVariable.block`);
  - restaura `errorsList.add(UNEXPECTED_STATUS_COMMAND)` no catch de `PalException` (regressão preexistente).

  ## Como validar

  1. Build do flavor `positivoSeriesL` (ou qualquer flavor cujo HAL não tenha suporte a Mifare):
     ./gradlew :app:installPositivoSeriesLDebug

  2. Abrir a `MifareActivity` e acionar **Detect card**.
  3. **Esperado**: toast "Erro na detecção" e log `errorsList: [NO_MIFARE_SUPPORT]`, sem crash do processo.
  4. **Antes do fix**: o app encerrava com `FATAL EXCEPTION: AsyncTask #1` no logcat.

  ---

  - Fixes [PRJHW-3602](https://allstone.atlassian.net/browse/PRJHW-3602)
  
  ### Dependência
  - Requer [stone-payments/pos-android-sdk#1525](https://github.com/stone-payments/pos-android-sdk/pull/1525) mergeado e tag `4.16.2` publicada no PackageCloud.
  
  # Checklist
  
  <!-- Verifique os itens abaixo e preencha com um X entre os colchetes nos que foram concluídos antes de enviar -->
  
  - [x] Testei as alterações localmente.
  - [x] Atualizei qualquer documentação relevante.
  - [x] Verifiquei que não há problemas de Lint ou formatação.
  - [x] Confirmei que o código segue as diretrizes de contribuição do projeto.
  

  [PRJHW-3602]: https://allstone.atlassian.net/browse/PRJHW-3602

[PRJHW-3602]: https://allstone.atlassian.net/browse/PRJHW-3602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ