### PR TITLE
[PRJHW-4664] Fix: use gertec-series7 adapter and bump SDK to 4.16.3 to fix GPOS730 crash

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     sunmiSeriesPImplementation "br.com.stone:stone-sdk-posandroid-sunmi:$stone_sdk_version"
     tectoySeriesTImplementation "br.com.stone:stone-sdk-posandroid-tectoy:$stone_sdk_version"
     gertecGpos700Implementation "br.com.stone:stone-sdk-posandroid-gertec:$stone_sdk_version"
-    gertecGposSeries7Implementation "br.com.stone:stone-sdk-posandroid-gertec:$stone_sdk_version"
+    gertecGposSeries7Implementation "br.com.stone:stone-sdk-posandroid-gertec-series7:$stone_sdk_version"
     positivoSeriesLImplementation "br.com.stone:stone-sdk-posandroid-positivo:$stone_sdk_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     testImplementation "io.mockk:mockk:1.10.6"

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         kotlin_version = '2.1.21'
-        stone_sdk_version = '4.16.2'
+        stone_sdk_version = '4.16.3'
 
         localProp = new Properties()
         fileName = 'local.properties'


### PR DESCRIPTION
## Descrição

Corrige o **crash do app demo ao transacionar no Gertec GPOS730**. Duas mudanças:

```diff
# app/build.gradle  (flavor gertecGposSeries7 usa o adapter dedicado da família Series7)
- gertecGposSeries7Implementation "br.com.stone:stone-sdk-posandroid-gertec:$stone_sdk_version"
+ gertecGposSeries7Implementation "br.com.stone:stone-sdk-posandroid-gertec-series7:$stone_sdk_version"

# build.gradle  (SDK com o halGertecSeries7 3.0.23)
- stone_sdk_version = '4.16.2'
+ stone_sdk_version = '4.16.3'
```

### Contexto / Causa raiz

O flavor `gertecGposSeries7` apontava para o adapter **legado** `stone-sdk-posandroid-gertec` (que traz a GEDI wangpos `posandroid-manufacturer-gertec:1.28.9`), incompatível com o hardware **Urovo MAXQ3250** do GPOS730 — o `PAL.initialize` não completava e a transação crashava (`PaymentProvider.stopPayment` NPE).

O SDK já publica um adapter dedicado para essa família, **`stone-sdk-posandroid-gertec-series7`** (GEDI gposNeo/Urovo). Trocar o flavor para ele resolve a seleção do HAL correto. Além disso, o `series7` na 4.16.2 ainda fixava a GEDI `3.0.12`, que tinha um bug no fluxo de cartão (`OutputCallbacks.Text` chamando `startActivity` sem `FLAG_ACTIVITY_NEW_TASK`); por isso o bump para **4.16.3**, que consome a `3.0.23` corrigida.

> Investigação mostrou que **não foi preciso mexer no `pos-android-hal`/AutoProvider**: o GPOS730 reporta `Build.MANUFACTURER = "Gertec"`, então o provider já resolve corretamente. O problema era a versão do adapter/GEDI consumida.

### Dependência

- ⛓️ Depende do **[pos-android-sdk#1532](https://github.com/stone-payments/pos-android-sdk/pull/1532)** (`fix: bump halGertecSeries7 to 3.0.23`), que produz o **`stone-sdk-posandroid-gertec-series7:4.16.3`**. Mergear/publicar o SDK 4.16.3 antes deste PR.

### Validação (device GPOS730, SN 6801012549000011)

APK buildado do zero com a cadeia oficial (sem `force`/mavenLocal):

- ✅ `PAL initialize = 0`, tabelas EMV carregadas
- ✅ Leitura de cartão por aproximação + kernel EMV (Mastercard / "Credito Nubank")
- ✅ **Zero `FATAL EXCEPTION`** (crash do GPOS730 eliminado)
- ℹ️ A autorização online não concluiu apenas por erro de **rede/DNS** ao alcançar o host de staging no ambiente de teste — sem relação com o fix.

### JIRA
- Fixes [PRJHW-4664](https://allstone.atlassian.net/browse/PRJHW-4664)


https://github.com/user-attachments/assets/34704e23-201e-4976-8ff7-0e96436aa8f6


[PRJHW-4664]: https://allstone.atlassian.net/browse/PRJHW-4664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ