### PR TITLE
fix: pin Kotlin jvmTarget to 17 to match compileOptions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,6 +36,14 @@ android {
         exclude 'META-INF/client_release.kotlin_module'
     }
 }
+kotlin {
+    compilerOptions {
+        // Must match compileOptions above. Without this the Kotlin target defaults
+        // to the JDK running Gradle (21 with Android Studio's JBR), which fails the
+        // JVM-target consistency check against javac's 17.
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
+}
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.2.0'


### PR DESCRIPTION
<!-- Por favor, forneça abaixo uma breve descrição das mudanças incluídas neste Pull Request -->

Corrige a falha de build do módulo `app` ao compilar pelo Android Studio:

```
Inconsistent JVM-target compatibility detected for tasks
'compileGertecGpos700DebugJavaWithJavac' (17) and 'compileGertecGpos700DebugKotlin' (21)
```

**Causa raiz:** o módulo `app` fixa o javac em Java 17 via `compileOptions` (`sourceCompatibility` / `targetCompatibility`), mas nunca declarou `jvmTarget` para o Kotlin nem um JVM toolchain. Sem essa declaração, o KGP 2.1.21 assume como padrão a versão do JDK que está rodando o daemon do Gradle:

| JDK do Gradle | `jvmTarget` do Kotlin | target do javac | Resultado |
| --- | --- | --- | --- |
| JBR embutido do Android Studio (21.0.10) | `JVM_21` | 17 | ❌ falha na validação de consistência |
| JDK 17 (terminal / CI) | `JVM_17` | 17 | ✅ compila |

O problema real, portanto, era o build ser **dependente do ambiente**. O CI nunca acusou porque o pipeline instala Java 17 explicitamente (`JavaToolInstaller@0`, `versionSpec: '17'` em `azure-pipelines.yml`), fazendo os dois targets coincidirem por acidente — o erro aparece para quem compila pelo Android Studio, que traz o JBR 21 embutido.

**Mudança** (`app/build.gradle`, único arquivo alterado): alinha o bytecode do Kotlin ao `compileOptions` que já existia.

```diff
+ kotlin {
+     compilerOptions {
+         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+     }
+ }
```

Alternativa considerada e descartada: `kotlin { jvmToolchain(17) }`, que é o que o próprio diagnóstico do Kotlin sugere. Exigiria um JDK 17 detectável ou provisionável em todo ambiente (agentes de CI e máquinas que só tenham o JDK 21) e mudaria qual JDK executa o javac. Fixar o `jvmTarget` é a mudança mínima para a causa raiz e mantém o comportamento do pipeline idêntico.

## Como validar

Reproduzindo o cenário que falhava, com o Gradle rodando sob o JBR do Android Studio:

```bash
./gradlew -Dorg.gradle.java.home=/opt/android-studio/jbr :app:compileGertecGpos700DebugKotlin
```

- Antes: `Execution failed for task ':app:compileGertecGpos700DebugKotlin'` com o erro acima
- Depois: `BUILD SUCCESSFUL`

O caminho usado pelo CI (JDK 17) segue passando, e também rodei `:app:packageGertecGposSeries7Debug` sob o JBR 21 para confirmar que o build avança até o empacotamento do APK.

## Lint

`./gradlew :app:lintGertecGpos700Debug` executado nas duas pontas, sob o mesmo JDK 17:

| Branch | Resultado |
| --- | --- |
| `master` | 7 erros, 124 warnings — `BUILD FAILED` |
| esta PR | 7 erros, 124 warnings — `BUILD FAILED` |

Os dois relatórios são idênticos. A única diferença é o número de linha dos warnings `GradleDependency` / `NewerVersionAvailable` de `app/build.gradle`, deslocados em 8 linhas — exatamente as 8 linhas que esta PR adiciona. Nenhum achado foi introduzido ou removido pela mudança.

Os 7 erros são anteriores a esta PR e não têm relação com ela: 6 × `MissingPermission` (`BLUETOOTH_CONNECT`) em `DevicesActivity.java` e 1 × `CoarseFineLocation` vindo do `AndroidManifest.xml` do próprio `stone-sdk-4.16.3`. É também por isso que o pipeline roda com `-x lint`. Como o lint do projeto não passa hoje, o item correspondente do checklist ficou desmarcado — embora esta PR não piore o resultado.

Detalhe que reforça o fix: no `master`, sob o JBR 21, o lint nem chega a executar — o build falha antes, exatamente no erro de JVM-target que esta PR corrige.

A alteração é de configuração de build e não exigiu mudança de documentação.

---

# Checklist

<!-- Verifique os itens abaixo e preencha com um X entre os colchetes nos que foram concluídos antes de enviar -->

- [x] Testei as alterações localmente.
- [ ] Atualizei qualquer documentação relevante.
- [ ] Verifiquei que não há problemas de Lint ou formatação.
- [x] Confirmei que o código segue as diretrizes de contribuição do projeto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
